### PR TITLE
Add custom githooks folder with pre-push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Prevent push of commits where the log message starts with a lower case.
+
+remote="$1"
+url="$2"
+protected_branch='master'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	if [ "$local_sha" = $z40 ]
+	then
+		# Handle delete
+		:
+	else
+		if [ $protected_branch = $current_branch ]
+		then
+			if [ "$remote_sha" = $z40 ]
+			then
+				# New branch, examine all commits
+				range="$local_sha"
+			else
+				# Update to existing branch, examine new commits
+				range="$remote_sha..$local_sha"
+			fi
+		
+			# Throw error when git and changelog can't be validated
+			wrongCommits=`git log --format=%s "$range" | grep '^[a-z]'`
+			if [ -n "$wrongCommits" ]
+			then
+				echo >&2 "Found unsquashed temporary commits! (their commit message doesnt start with uppercase A-Z):
+$wrongCommits"
+				exit 1
+			fi
+		else
+			exit 0 # push will execute
+		fi
+		
+		exit 0
+	fi
+done
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## GIT
+
+To enable custom pre-push hook, update git configuration to let it know where our hook files lie:
+
+```
+`git config core.hooksPath .githooks`
+```
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -52,8 +60,6 @@ npx cross-env LOGIN_USERNAME=myuser LOGIN_PASSWORD=mysecret npm run e2e:debug
 ```
 
 Opens UI for e2e tests overview with custom user account.
-
-
 
 ### `npm run build`
 


### PR DESCRIPTION
We had problems pushing `fixup` commits to master. A pre-push script
has been added to stop pushing to master if any new commits include
message that start with a lower case letter (e.g. fixup).